### PR TITLE
Consider empty repository situation

### DIFF
--- a/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
+++ b/src/main/java/org/jenkinsci/maven/plugins/hpi/AbstractHpiMojo.java
@@ -847,7 +847,10 @@ public abstract class AbstractHpiMojo extends AbstractJenkinsMojo {
             if (p.waitFor()!=0)
                 return null;    // git rev-parse failed to run
 
-            return v.trim().substring(0,8);
+            if (v.length()<8)
+                return null;    // git repository present, but without commits
+
+            return v.substring(0,8);
         } catch (IOException | InterruptedException e) {
             LOGGER.log(Level.FINE, "Failed to run git rev-parse HEAD",e);
             return null;


### PR DESCRIPTION
Happened to me when I create a new plugin, executed `git init`, and then `mvn clean verify`.

When there is no commit, the outcome is just `HEAD` instead of the commit sha. Due to it having a length of 4, the substring fails.

> [ERROR] Failed to execute goal org.jenkins-ci.tools:maven-hpi-plugin:3.28:test-hpl (default-test-hpl) on project sudo-mode: Execution default-test-hpl of goal org.jenkins-ci.tools:maven-hpi-plugin:3.28:test-hpl failed: begin 0, end 8, length 4 -> [Help 1]

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
